### PR TITLE
feat: added autoversioning capability to the premake script

### DIFF
--- a/tools/autoversion.h.in
+++ b/tools/autoversion.h.in
@@ -1,0 +1,19 @@
+#ifndef AUTOVERSION_H
+#define AUTOVERSION_H
+
+/// @file autoversion.h
+/// @brief the automatically generated versioning file, provides useful versioning macros
+///
+/// the version is determined based on the tag provided by github. The tag should be based on
+/// SemVer. Additionally, the commit hash is stored in case that could be of use. Lastly, if
+/// there are local changes (i.e. it's  "dirty") the version string will end with a '+'
+
+// DO NOT MODIFY THIS FILE! (unless you know what you're doing!)
+
+#define @PROJECT_NAME@_VERSION_STRING "@VERSION_STRING@"
+#define @PROJECT_NAME@_VERSION_MAJOR @VERSION_MAJOR@
+#define @PROJECT_NAME@_VERSION_MINOR @VERSION_MINOR@
+#define @PROJECT_NAME@_VERSION_PATCH @VERSION_PATCH@
+#define @PROJECT_NAME@_COMMIT_HASH "@COMMIT_HASH@"
+
+#endif // AUTOVERSION_H


### PR DESCRIPTION
During configuration, a prompt is now supplied to determine if auto-versioning should be applied. If used, an "autoversion.h" file is created in the '/src/' directory with values populated from the git tag. If no git tag is found/there is an error retrieving the value(s), default values of 0 are utilized.

If auto-versioning is not used, nothing has changed _except_ for cleaning up some pre-defined fields in an object in the '/premake/premake5.lua' script which were not actually needed.

To access the values associated with the version, the following macros are supplied (where `$PRJ.NAME$` is replaced by the project's name (in caps) with any spaces/hyphens replaced with underscores:

- $PRJ.NAME$_VERSION_STRING
- $PRJ.NAME$_VERSION_MAJOR
- $PRJ.NAME$_VERSION_MINOR
- $PRJ.NAME$_VERSION_PATCH
- $PRJ.NAME$_COMMIT_HASH

For example, a project "Example Project" in the directory '/example project/' would have macros EXAMPLE_PROJECT_VERSION_STRING and so on.